### PR TITLE
~ Updated Linq queries in WindowsLayoutEditor::Setup_EDITOR; there's now...

### DIFF
--- a/Assets/UI.Windows/Extensions/ME/EditorUtilities.cs
+++ b/Assets/UI.Windows/Extensions/ME/EditorUtilities.cs
@@ -9,39 +9,6 @@ namespace ME {
 
 	public partial class EditorUtilities {
 
-		public static void ClearLayoutElement(UnityEngine.UI.Windows.WindowLayoutElement layoutElement) {
-			
-			if (layoutElement.editorLabel == null) return;
-
-			var root = layoutElement.gameObject.transform.root.gameObject;
-
-			if (EditorUtilities.IsPrefab(root) == false) {
-
-				GameObject.DestroyImmediate(layoutElement.editorLabel);
-				return;
-
-			}
-
-			var tag = layoutElement.tag;
-
-			// Create prefab instance
-			var instance = GameObject.Instantiate(root) as GameObject;
-			var layout = instance.GetComponent<UnityEngine.UI.Windows.WindowLayout>();
-			layout.hideFlags = HideFlags.HideAndDontSave;
-			if (layout != null) {
-
-				layoutElement = layout.GetRootByTag(tag);
-				if (layoutElement != null) EditorUtilities.ClearLayoutElement(layoutElement);
-
-				// Apply prefab
-				PrefabUtility.ReplacePrefab(instance, root, ReplacePrefabOptions.ReplaceNameBased);
-
-				// Clean up
-				GameObject.DestroyImmediate(instance);
-
-			}
-
-		}
 		/*
 		public static void DestroyImmediateHidden<T>(this MonoBehaviour root) where T : Component {
 

--- a/Assets/UI.Windows/Layouts/Editor/WindowLayoutEditor.cs
+++ b/Assets/UI.Windows/Layouts/Editor/WindowLayoutEditor.cs
@@ -9,7 +9,9 @@ namespace UnityEditor.UI.Windows {
 	[CustomEditor(typeof(WindowLayout))]
 	[CanEditMultipleObjects()]
 	public class WindowLayoutEditor : Editor {
-		
+
+		public bool drawEditorRects = false;
+
 		private bool isDirty = false;
 
 		public override void OnInspectorGUI() {
@@ -31,7 +33,12 @@ namespace UnityEditor.UI.Windows {
 				this.isDirty = false;
 
 			}
+			
+		}
 
+		public void OnSceneGUI() {
+
+			this.DrawElements( target as WindowLayout );
 		}
 
 		private void ApplyRoot(UnityEngine.UI.Windows.WindowLayout _target) {
@@ -77,7 +84,6 @@ namespace UnityEditor.UI.Windows {
 
 		}
 
-		public bool drawEditorRects = false;
 		private void UpdateLinks(UnityEngine.UI.Windows.WindowLayout _target) {
 
 			this.Setup_EDITOR(_target);
@@ -87,7 +93,7 @@ namespace UnityEditor.UI.Windows {
 		
 		private void Update_EDITOR(UnityEngine.UI.Windows.WindowLayout _target) {
 
-			foreach (var element in _target.elements) element.Update_EDITOR();
+			//foreach (var element in _target.elements) element.Update_EDITOR();
 
 			#region COMPONENTS
 			_target.canvas = _target.GetComponentsInChildren<Canvas>(true)[0];
@@ -119,11 +125,9 @@ namespace UnityEditor.UI.Windows {
 
 		private void Setup_EDITOR(UnityEngine.UI.Windows.WindowLayout _target) {
 			
-			_target.elements = _target.elements.Where((e) => e != null).ToList();
-			
 			var usedTags = new List<LayoutTag>();
 			var elements = _target.GetComponentsInChildren<WindowLayoutElement>(true);
-			_target.elements = _target.elements.Where((e) => elements.Contains(e)).ToList();
+			_target.elements = _target.elements.Where(e => e!=null && elements.Contains(e)).ToList();
 			
 			foreach (var element in elements) {
 				
@@ -172,7 +176,15 @@ namespace UnityEditor.UI.Windows {
 			}
 			
 		}
-		
+
+		private void DrawElements(UnityEngine.UI.Windows.WindowLayout _target) {
+
+			foreach ( var each in _target.elements ) {
+				
+				each.DrawHandle();
+			}
+		}
+
 		private LayoutTag GetTag(List<LayoutTag> used) {
 			
 			var tags = System.Enum.GetValues(typeof(LayoutTag));

--- a/Assets/UI.Windows/Layouts/Editor/WindowLayoutElementEditor.cs
+++ b/Assets/UI.Windows/Layouts/Editor/WindowLayoutElementEditor.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using System.Collections;
+using UnityEngine.UI.Windows;
+
+[CustomEditor(typeof(WindowLayoutElement))]
+public class WindowLayoutElementEditor : Editor {
+
+	private WindowLayoutElement target {
+
+		get { return base.target as WindowLayoutElement; }
+	}
+
+	public void OnSceneGUI() {
+
+		var ownerLayout = target.transform.root.GetComponentInChildren<WindowLayout>();
+		
+		foreach ( var each in ownerLayout.elements) {
+
+			each.DrawHandle( isActive: each == target );	
+		}
+	}
+}

--- a/Assets/UI.Windows/Layouts/Editor/WindowLayoutElementEditor.cs.meta
+++ b/Assets/UI.Windows/Layouts/Editor/WindowLayoutElementEditor.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 83b0973772e45e64691497d60cc2d2bd
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/Assets/UI.Windows/Layouts/WindowLayoutElement.cs
+++ b/Assets/UI.Windows/Layouts/WindowLayoutElement.cs
@@ -35,12 +35,7 @@ namespace UnityEngine.UI.Windows {
 		public Color editorColor;
 		public void TurnOff_EDITOR() {
 
-			if (this.editorActive == false) return;
-
 			this.editorActive = false;
-
-			ME.EditorUtilities.ClearLayoutElement(this);
-
 		}
 
 		public void TurnOn_EDITOR() {
@@ -54,94 +49,71 @@ namespace UnityEngine.UI.Windows {
 			this.Update();
 
 		}
-
-		[HideInInspector][SerializeField]
-		public GameObject editorLabel;
-		public override void Update_EDITOR() {
+		
+		public string GetDescription() {
 			
-			base.Update_EDITOR();
-
-			if (this.editorActive == false) return;
-
-			if (Application.isPlaying == true) {
-				/*
-				if (this.editorBody != null) {
-
-					Component.Destroy(this.editorBody);
-					Component.Destroy(this.GetComponent<CanvasRenderer>());
-
-				}
-				if (this.editorLabel != null) GameObject.Destroy(this.editorLabel);*/
-				return;
-
-			}
-
-			if (this.editorLabel == null) {
-
-				var t = this.transform.FindChild("__EditorLabel");
-				if (t != null) this.editorLabel = t.gameObject;
-
-			}
-
-			var descr = this.tag.ToString() + ": " + this.comment + "\n" + "(Animation: " + (this.animation != null ? this.animation.name : "None") + ")";
-
-			if (this.editorLabel == null) {
-
-				this.editorLabel = new GameObject("__EditorLabel");
-				this.editorLabel.transform.SetParent(this.transform);
-
-				this.editorLabel.hideFlags = HideFlags.HideAndDontSave;
-				this.CenterAndStretch(this.editorLabel.transform);
-
-				var subLabel = new GameObject("Label");
-				subLabel.transform.SetParent(this.editorLabel.transform);
-				this.CenterAndStretch(subLabel.transform);
-				
-				var image = this.editorLabel.AddComponent<Image>();
-				image.color = this.editorColor;
-
-				var layout = this.editorLabel.AddComponent<LayoutElement>();
-				layout.ignoreLayout = true;
-
-				var shadow = subLabel.AddComponent<Shadow>();
-				shadow.effectDistance = new Vector2(1f, -1f);
-				shadow.useGraphicAlpha = true;
-
-				var text = subLabel.AddComponent<Text>();
-				text.alignment = TextAnchor.MiddleCenter;
-				text.fontStyle = FontStyle.Bold;
-				text.horizontalOverflow = HorizontalWrapMode.Overflow;
-				text.verticalOverflow = VerticalWrapMode.Overflow;
-				text.fontSize = 20;
-				var color = Color.white;
-				color.a = 0.5f;
-				text.color = color;
-				text.text = descr;
-
-			} else {
-
-				var text = this.editorLabel.GetComponentInChildren<Text>();
-
-				this.editorLabel.transform.SetAsLastSibling();
-				if (text != null) text.text = descr;
-
-			}
-
+			return this.tag + ": " + this.comment + "\n" + "(Animation: " + (this.animation != null ? this.animation.name : "None") + ")";
 		}
 
-		private void CenterAndStretch(Transform tr) {
+		public GUIStyle GetActiveGUIStyle() {
 
-			var rect = tr as RectTransform;
-			if (rect == null) rect = tr.gameObject.AddComponent<RectTransform>();
+			var result = new GUIStyle { fontStyle = FontStyle.Bold, fontSize = 20, alignment = TextAnchor.MiddleCenter };
 
-			rect.anchorMin = Vector2.zero;
-			rect.anchorMax = Vector2.one;
-			rect.pivot = Vector2.one * 0.5f;
-			rect.anchoredPosition3D = Vector3.zero;
-			rect.sizeDelta = Vector2.zero;
-			rect.localScale = Vector3.one;
+			var color = Color.white;
+			color.a = 0.7f;
 
+			result.normal.textColor = color;
+
+			return result;
 		}
+
+		public GUIStyle GetInactiveGUIStyle() {
+
+			var result = new GUIStyle { fontStyle = FontStyle.Bold, fontSize = 20, alignment = TextAnchor.MiddleCenter };
+
+			var color = Color.white;
+			color.a = 0.2f;
+
+			result.normal.textColor = color;
+
+			return result;
+		}
+
+		public void DrawHandle(bool isActive = true) {
+
+			var corners = new Vector3[4];
+
+			var textScaleFactor = 100;
+			var maxTextSize = 100;
+
+			#region Layout pass
+
+			( transform as RectTransform ).GetWorldCorners( corners );
+
+			var targetColor = editorColor;
+			if ( !isActive ) {
+
+				var inactiveColor = Color.gray;
+				inactiveColor.a = 0f;
+
+				targetColor += inactiveColor * 0.3f;
+			}
+
+			UnityEditor.Handles.DrawSolidRectangleWithOutline( corners, targetColor, targetColor );
+
+			#endregion
+
+			#region Text pass
+
+			var style = isActive ? GetActiveGUIStyle() : GetInactiveGUIStyle();
+			style.fontSize = (int)( style.fontSize / UnityEditor.HandleUtility.GetHandleSize( transform.position ) * textScaleFactor );
+			style.fontSize = Mathf.Clamp( style.fontSize, 1, maxTextSize );
+
+			UnityEditor.Handles.Label( transform.position, GetDescription(), style );
+
+			#endregion
+		}
+
 		#endif
 		
 	}


### PR DESCRIPTION
... one less ToList() conversion

~ Redid layout display; got rid of hidden objects in favour of UnityEditor's built-in handle draw methods
- WindowLayoutElementEditor that makes sure that whole layout is drawn even if only a child element is selected; on top of that currently selected element is highlighted in layout display
